### PR TITLE
Fix typo in .gitignore for credentials.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 
 # testing
 /coverage
-/creditentials.json
+/credentials.json
 
 # next.js
 /.next/


### PR DESCRIPTION
## Description
Fix the typo for the testing json file.
