### PR TITLE
Update command to run backend with Python module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ This project is developed in collaboration with Oregon State University and AI E
    ```
    ```bash
    # For Backend, from the backend directory
-   uvicorn main:app --reload
+   python -m uvicorn main:app --reload
    ```
 
 4. Open [http://localhost:3000](http://localhost:3000) in your browser


### PR DESCRIPTION
Fixed error. Didn't say to run `python -m` before uvicorn.
