### PR TITLE
feat: textbook upload + question bank seeding pipeline

### DIFF
--- a/AI_core/quiz_pipeline/seed_textbook.py
+++ b/AI_core/quiz_pipeline/seed_textbook.py
@@ -1,31 +1,3 @@
-#!/usr/bin/env python3
-"""
-seed_textbook.py — One-shot script to compile a textbook into MongoDB
-
-  1. Hashes the textbook PDF → deterministic textbookId
-  2. Stores textbook metadata in the ``textbooks`` collection
-  3. Reads all generated quiz JSONs from ``generated_quizzes/``
-  4. Inserts them into the ``question_bank`` collection, tagged with textbookId
-  5. Creates a unique index on (textbookId, quizId) for dedup
-
-After this, when an instructor creates a course and picks this textbook,
-the course-creation endpoint copies quizzes from ``question_bank`` into
-the course-specific ``quizzes`` collection.
-
-Usage
-    # With defaults (reads the PDF from rag_pipeline/, uses MONGO_URI env var):
-    python seed_textbook.py
-
-    # Point at a specific PDF and Mongo:
-    python seed_textbook.py \\
-        --pdf path/to/textbook.pdf \\
-        --mongo "mongodb+srv://user:pass@cluster.mongodb.net" \\
-        --db instructor_main
-
-    # Dry run (shows what would happen, no writes):
-    python seed_textbook.py --dry-run
-"""
-
 from __future__ import annotations
 
 import argparse
@@ -44,8 +16,6 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 
-# ── Paths (relative to this script in AI_core/quiz_pipeline/) ─────────
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 QUIZ_OUTPUT_DIR = SCRIPT_DIR / "generated_quizzes"
 
@@ -54,8 +24,6 @@ DEFAULT_PDF = (
     SCRIPT_DIR.parent / "rag_pipeline"
     / "Research-Methods-in-Psychology-1641401927 (1) copy.pdf"
 )
-
-# ── Helpers ───────────────────────────────────────────────────────────
 
 def hash_pdf(pdf_path: Path) -> str:
     """SHA-256 hash of the PDF file."""
@@ -132,23 +100,28 @@ def main():
         log.info("  [DRY RUN] Would store textbook metadata in MongoDB")
         log.info("")
         log.info("=" * 60)
-        log.info("STEP 2: Would seed %d quiz JSON files", len(json_files))
+        log.info("STEP 2: Would build 1 question_bank doc from %d quiz JSON files",
+                 len(json_files))
         log.info("=" * 60)
+        total_questions = 0
         for fp in json_files:
             quiz = json.loads(fp.read_text(encoding="utf-8"))
+            n_q = len(quiz.get("questions", []))
+            total_questions += n_q
             log.info(
-                "  %s/%s  →  quizId=%s  section=%s  questions=%d",
+                "  + %s/%s  →  quizId=%s  section=%s  questions=%d",
                 fp.parent.name,
                 fp.name,
                 quiz.get("quizId", "?"),
                 quiz.get("section", "?"),
-                len(quiz.get("questions", [])),
+                n_q,
             )
+        log.info("  Would upsert 1 question_bank doc: %d sections, %d questions",
+                 len(json_files), total_questions)
         log.info("")
         log.info("Run without --dry-run to actually write to MongoDB.")
         return
 
-    # ── Connect to MongoDB ───────────────────────────────────────────
 
     try:
         from pymongo import MongoClient
@@ -167,11 +140,13 @@ def main():
 
     if existing:
         log.info("  Textbook %s already exists in MongoDB — skipping insert", textbook_id)
+        textbook_title = existing.get("title", "")
     else:
+        textbook_title = args.pdf.stem.replace("_", " ").replace("-", " ")
         doc = {
             "textbookId": textbook_id,
             "filename": args.pdf.name,
-            "title": args.pdf.stem.replace("_", " ").replace("-", " "),
+            "title": textbook_title,
             "sha256": sha,
             "totalChapters": 13,
             "pipelineStatus": "uploaded",
@@ -182,20 +157,29 @@ def main():
 
     log.info("")
     log.info("=" * 60)
-    log.info("STEP 2: Seeding question bank")
+    log.info("STEP 2: Building question bank (one doc per textbook)")
     log.info("=" * 60)
     log.info("  Found %d quiz JSON files", len(json_files))
 
     qbank_coll = db["question_bank"]
 
-    # Create unique index
+    # Drop legacy multi-field index from prior schema, if it exists
+    try:
+        qbank_coll.drop_index("textbookId_quizId_unique")
+        log.info("  Dropped legacy index textbookId_quizId_unique")
+    except Exception:
+        pass  # Index does not exist — that is fine
+
+    # Unique index on textbookId (one question bank doc per textbook)
     qbank_coll.create_index(
-        [("textbookId", 1), ("quizId", 1)],
+        "textbookId",
         unique=True,
-        name="textbookId_quizId_unique",
+        name="textbookId_unique",
     )
 
-    inserted = 0
+    # ── Build the sections array ─────────────────────────────────────
+
+    sections = []
     skipped = 0
 
     for fp in json_files:
@@ -206,52 +190,44 @@ def main():
             skipped += 1
             continue
 
-        # Tag with real textbookId + source info
-        quiz["textbookId"] = textbook_id
-        quiz["sourceModel"] = fp.parent.name   # "opus" or "sonnet"
-        quiz["sourceFile"] = fp.name
-        quiz["seededAt"] = datetime.now(timezone.utc).isoformat()
+        sections.append({
+            "section":     quiz.get("section"),        # e.g. "Chapter 1"
+            "quizId":      quiz.get("quizId"),         # e.g. "QUIZ_SONNET_CH01"
+            "sourceModel": fp.parent.name,             # "opus" or "sonnet"
+            "sourceFile":  fp.name,
+            "questions":   quiz.get("questions", []),
+        })
+        log.info(
+            "  + %s/%s  →  quizId=%s  (%d questions)",
+            fp.parent.name,
+            fp.name,
+            quiz.get("quizId"),
+            len(quiz.get("questions", [])),
+        )
 
-        try:
-            qbank_coll.insert_one(quiz)
-            inserted += 1
-            log.info(
-                "  ✓ %s/%s  →  quizId=%s  (%d questions)",
-                fp.parent.name,
-                fp.name,
-                quiz.get("quizId"),
-                len(quiz.get("questions", [])),
-            )
-        except Exception as exc:
-            # Duplicate key = already seeded
-            log.info("  ○ %s/%s  →  already exists, skipped", fp.parent.name, fp.name)
-            skipped += 1
+    # ── Upsert the single question_bank document ─────────────────────
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    bank_doc = {
+        "textbookId":    textbook_id,
+        "title":         textbook_title,
+        "sectionCount":  len(sections),
+        "questionCount": sum(len(s["questions"]) for s in sections),
+        "sections":      sections,
+        "seededAt":      now_iso,
+    }
+
+    qbank_coll.replace_one(
+        {"textbookId": textbook_id},
+        bank_doc,
+        upsert=True,
+    )
 
     # Update pipeline status
     textbooks_coll.update_one(
         {"textbookId": textbook_id},
         {"$set": {"pipelineStatus": "quizzes_seeded"}},
     )
-
-
-    log.info("")
-    log.info("=" * 60)
-    log.info("DONE")
-    log.info("=" * 60)
-    log.info("  textbookId:  %s", textbook_id)
-    log.info("  Inserted:    %d quiz documents", inserted)
-    log.info("  Skipped:     %d (dupes or validation errors)", skipped)
-    log.info("")
-    log.info("  Next steps:")
-    log.info("    1. Use this textbookId when creating courses in the UI")
-    log.info("    2. The course creation endpoint will auto-copy these")
-    log.info("       quizzes into the course-specific quiz collection")
-    log.info("")
-    log.info("  To verify, run:")
-    log.info("    python seed_textbook.py --dry-run")
-    log.info("  Or in mongo shell:")
-    log.info('    db.question_bank.find({textbookId: "%s"}).count()', textbook_id)
-
 
 if __name__ == "__main__":
     main()

--- a/AI_core/quiz_pipeline/seed_textbook.py
+++ b/AI_core/quiz_pipeline/seed_textbook.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+seed_textbook.py — One-shot script to compile a textbook into MongoDB
+
+  1. Hashes the textbook PDF → deterministic textbookId
+  2. Stores textbook metadata in the ``textbooks`` collection
+  3. Reads all generated quiz JSONs from ``generated_quizzes/``
+  4. Inserts them into the ``question_bank`` collection, tagged with textbookId
+  5. Creates a unique index on (textbookId, quizId) for dedup
+
+After this, when an instructor creates a course and picks this textbook,
+the course-creation endpoint copies quizzes from ``question_bank`` into
+the course-specific ``quizzes`` collection.
+
+Usage
+    # With defaults (reads the PDF from rag_pipeline/, uses MONGO_URI env var):
+    python seed_textbook.py
+
+    # Point at a specific PDF and Mongo:
+    python seed_textbook.py \\
+        --pdf path/to/textbook.pdf \\
+        --mongo "mongodb+srv://user:pass@cluster.mongodb.net" \\
+        --db instructor_main
+
+    # Dry run (shows what would happen, no writes):
+    python seed_textbook.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+# ── Paths (relative to this script in AI_core/quiz_pipeline/) ─────────
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+QUIZ_OUTPUT_DIR = SCRIPT_DIR / "generated_quizzes"
+
+# The textbook PDF lives one level up in rag_pipeline/
+DEFAULT_PDF = (
+    SCRIPT_DIR.parent / "rag_pipeline"
+    / "Research-Methods-in-Psychology-1641401927 (1) copy.pdf"
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def hash_pdf(pdf_path: Path) -> str:
+    """SHA-256 hash of the PDF file."""
+    h = hashlib.sha256()
+    with open(pdf_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def make_textbook_id(sha: str) -> str:
+    return f"TB_{sha[:12]}"
+
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Seed a textbook + its question bank into MongoDB."
+    )
+    parser.add_argument(
+        "--pdf",
+        type=Path,
+        default=DEFAULT_PDF,
+        help=f"Path to the textbook PDF (default: {DEFAULT_PDF.name})",
+    )
+    parser.add_argument(
+        "--mongo",
+        default=os.environ.get("MONGO_URI")
+             or os.environ.get("INSTRUCTOR_MONGODB_URL")
+             or "mongodb://localhost:27017",
+        help="MongoDB connection URI (or set MONGO_URI / INSTRUCTOR_MONGODB_URL env var)",
+    )
+    parser.add_argument(
+        "--db",
+        default=os.environ.get("INSTRUCTOR_MAIN_DB", "instructor_main"),
+        help="MongoDB database name (default: instructor_main)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without writing to MongoDB.",
+    )
+    args = parser.parse_args()
+
+    # ── Validate inputs ──────────────────────────────────────────────
+
+    if not args.pdf.exists():
+        log.error("PDF not found: %s", args.pdf)
+        sys.exit(1)
+
+    if not QUIZ_OUTPUT_DIR.exists():
+        log.error("Quiz output directory not found: %s", QUIZ_OUTPUT_DIR)
+        log.error("Run quiz_generator.py first to generate quiz JSONs.")
+        sys.exit(1)
+
+    json_files = sorted(QUIZ_OUTPUT_DIR.rglob("*.json"))
+    if not json_files:
+        log.error("No .json files found in %s", QUIZ_OUTPUT_DIR)
+        sys.exit(1)
+
+    log.info("=" * 60)
+    log.info("STEP 1: Hashing PDF")
+    log.info("=" * 60)
+    log.info("  PDF: %s", args.pdf.name)
+
+    sha = hash_pdf(args.pdf)
+    textbook_id = make_textbook_id(sha)
+
+    log.info("  SHA-256:     %s", sha[:24] + "...")
+    log.info("  textbookId:  %s", textbook_id)
+
+    if args.dry_run:
+        log.info("  [DRY RUN] Would store textbook metadata in MongoDB")
+        log.info("")
+        log.info("=" * 60)
+        log.info("STEP 2: Would seed %d quiz JSON files", len(json_files))
+        log.info("=" * 60)
+        for fp in json_files:
+            quiz = json.loads(fp.read_text(encoding="utf-8"))
+            log.info(
+                "  %s/%s  →  quizId=%s  section=%s  questions=%d",
+                fp.parent.name,
+                fp.name,
+                quiz.get("quizId", "?"),
+                quiz.get("section", "?"),
+                len(quiz.get("questions", [])),
+            )
+        log.info("")
+        log.info("Run without --dry-run to actually write to MongoDB.")
+        return
+
+    # ── Connect to MongoDB ───────────────────────────────────────────
+
+    try:
+        from pymongo import MongoClient
+    except ImportError:
+        log.error("pymongo not installed.  Run:  pip install pymongo")
+        sys.exit(1)
+
+    client = MongoClient(args.mongo, serverSelectionTimeoutMS=5000)
+    client.admin.command("ping")
+    log.info("  Connected to MongoDB")
+
+    db = client[args.db]
+
+    textbooks_coll = db["textbooks"]
+    existing = textbooks_coll.find_one({"textbookId": textbook_id})
+
+    if existing:
+        log.info("  Textbook %s already exists in MongoDB — skipping insert", textbook_id)
+    else:
+        doc = {
+            "textbookId": textbook_id,
+            "filename": args.pdf.name,
+            "title": args.pdf.stem.replace("_", " ").replace("-", " "),
+            "sha256": sha,
+            "totalChapters": 13,
+            "pipelineStatus": "uploaded",
+            "uploadedAt": datetime.now(timezone.utc).isoformat(),
+        }
+        textbooks_coll.insert_one(doc)
+        log.info("  Inserted textbook metadata: %s", textbook_id)
+
+    log.info("")
+    log.info("=" * 60)
+    log.info("STEP 2: Seeding question bank")
+    log.info("=" * 60)
+    log.info("  Found %d quiz JSON files", len(json_files))
+
+    qbank_coll = db["question_bank"]
+
+    # Create unique index
+    qbank_coll.create_index(
+        [("textbookId", 1), ("quizId", 1)],
+        unique=True,
+        name="textbookId_quizId_unique",
+    )
+
+    inserted = 0
+    skipped = 0
+
+    for fp in json_files:
+        quiz = json.loads(fp.read_text(encoding="utf-8"))
+
+        if quiz.get("_validation_errors"):
+            log.warning("  SKIP %s (has validation errors)", fp.name)
+            skipped += 1
+            continue
+
+        # Tag with real textbookId + source info
+        quiz["textbookId"] = textbook_id
+        quiz["sourceModel"] = fp.parent.name   # "opus" or "sonnet"
+        quiz["sourceFile"] = fp.name
+        quiz["seededAt"] = datetime.now(timezone.utc).isoformat()
+
+        try:
+            qbank_coll.insert_one(quiz)
+            inserted += 1
+            log.info(
+                "  ✓ %s/%s  →  quizId=%s  (%d questions)",
+                fp.parent.name,
+                fp.name,
+                quiz.get("quizId"),
+                len(quiz.get("questions", [])),
+            )
+        except Exception as exc:
+            # Duplicate key = already seeded
+            log.info("  ○ %s/%s  →  already exists, skipped", fp.parent.name, fp.name)
+            skipped += 1
+
+    # Update pipeline status
+    textbooks_coll.update_one(
+        {"textbookId": textbook_id},
+        {"$set": {"pipelineStatus": "quizzes_seeded"}},
+    )
+
+
+    log.info("")
+    log.info("=" * 60)
+    log.info("DONE")
+    log.info("=" * 60)
+    log.info("  textbookId:  %s", textbook_id)
+    log.info("  Inserted:    %d quiz documents", inserted)
+    log.info("  Skipped:     %d (dupes or validation errors)", skipped)
+    log.info("")
+    log.info("  Next steps:")
+    log.info("    1. Use this textbookId when creating courses in the UI")
+    log.info("    2. The course creation endpoint will auto-copy these")
+    log.info("       quizzes into the course-specific quiz collection")
+    log.info("")
+    log.info("  To verify, run:")
+    log.info("    python seed_textbook.py --dry-run")
+    log.info("  Or in mongo shell:")
+    log.info('    db.question_bank.find({textbookId: "%s"}).count()', textbook_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from modules.auth.routes import auth_router
 from modules.course.routes import courses_router
 from modules.quiz.routes import quiz_router
 from modules.chatbot.routes import chatbot_router
+from modules.textbook.routes import textbook_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -27,6 +28,7 @@ app.include_router(auth_router)
 app.include_router(courses_router)
 app.include_router(quiz_router)
 app.include_router(chatbot_router)
+app.include_router(textbook_router)
 
 
 @app.get("/")

--- a/backend/modules/course/routes.py
+++ b/backend/modules/course/routes.py
@@ -2,26 +2,37 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from db.utils import get_instructor_db
 from .models import CourseCreate
 from modules.auth.jwt_service import verify_access_token
-from datetime import datetime
+from datetime import datetime, timezone
 from bson import ObjectId
+import uuid
+import logging
+
+log = logging.getLogger(__name__)
 
 courses_router = APIRouter(prefix="/courses", tags=["Courses"])
 
-@courses_router.post("/create_course")
-async def create_course(course: CourseCreate, request: Request, db=Depends(get_instructor_db)):
+
+def _get_current_user(request: Request) -> str:
     token = request.cookies.get("access_token")
     if not token:
-        raise HTTPException(401, "not authenticated")
-
+        raise HTTPException(401, "Not authenticated")
     user_id = verify_access_token(token)
     if not user_id:
-        raise HTTPException(401, "invalid or expired token")
+        raise HTTPException(401, "Invalid or expired token")
+    return user_id
+
+
+@courses_router.post("/create_course")
+async def create_course(course: CourseCreate, request: Request, db=Depends(get_instructor_db)):
+    user_id = _get_current_user(request)
+
+    course_id = str(ObjectId())
 
     new_course = {
-        "_id": str(ObjectId()),
+        "_id": course_id,
         "userID": user_id,
         "textbookID": course.textbookID,
-        "createdAt": datetime.utcnow().isoformat() + "Z",
+        "createdAt": datetime.now(timezone.utc).isoformat(),
         "courseTitle": course.courseTitle,
         "courseTerm": course.courseTerm,
         "courseDescription": course.courseDescription,
@@ -29,31 +40,57 @@ async def create_course(course: CourseCreate, request: Request, db=Depends(get_i
     }
 
     await db["courses"].insert_one(new_course)
+
+    # ── Copy question bank into course-specific quizzes ──────────────
+    # Find all master quizzes for this textbook
+    bank_quizzes = await db["question_bank"].find(
+        {"textbookId": course.textbookID}
+    ).to_list(None)
+
+    copied = 0
+    for bq in bank_quizzes:
+        course_quiz = {
+            "_id": f"QUIZ{uuid.uuid4().hex[:6].upper()}",
+            "courseId": course_id,
+            "textbookId": course.textbookID,
+            "quizTitle": f"{bq.get('section', 'Quiz')} Quiz",
+            "quizStatus": "Draft",
+            "section": bq.get("section", ""),
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "description": f"Auto-generated from question bank ({bq.get('sourceModel', 'unknown')})",
+            "dueDate": "",
+            "totalPoints": len(bq.get("questions", [])),
+            "questions": [
+                {
+                    "questionId": q["questionId"],
+                    "questionPoints": 1,
+                    "question": q["question"],
+                    "answers": q["answers"],
+                }
+                for q in bq.get("questions", [])
+            ],
+            # Lineage back to the master copy
+            "sourceQuizId": bq.get("quizId"),
+            "sourceModel": bq.get("sourceModel"),
+        }
+        await db["quizzes"].insert_one(course_quiz)
+        copied += 1
+
+    log.info("Course %s created — copied %d quizzes from question bank", course_id, copied)
+
+    new_course["quizzesCopied"] = copied
     return new_course
 
 @courses_router.get("/fetch_courses")
 async def fetch_courses(request: Request, db=Depends(get_instructor_db)):
-    token = request.cookies.get("access_token")
-    if not token:
-        raise HTTPException(401, "not authenticated")
-
-    user_id = verify_access_token(token)
-    if not user_id:
-        raise HTTPException(401, "invalid or expired token")
-
+    user_id = _get_current_user(request)
     courses = await db["courses"].find({"userID": user_id}).to_list()
     return courses
 
 # Make sure user actually owns the course (Dylantest shoudl not be able to access it)
 @courses_router.get("/{course_id}")
 async def get_course(course_id: str, request: Request, db=Depends(get_instructor_db)):
-    token = request.cookies.get("access_token")
-    if not token:
-        raise HTTPException(401, "not authenticated")
-
-    user_id = verify_access_token(token)
-    if not user_id:
-        raise HTTPException(401, "invalid or expired token")
+    user_id = _get_current_user(request)
 
     course = await db["courses"].find_one({"_id": course_id, "userID": user_id})
     if not course:

--- a/backend/modules/textbook/models.py
+++ b/backend/modules/textbook/models.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class TextbookMeta(BaseModel):
+    """Metadata stored in the ``textbooks`` collection."""
+    textbookId: str          # deterministic hash of the PDF, e.g. "TB_a3f8c901e2b4"
+    filename: str            # original upload filename
+    title: str = ""          # human-friendly title (can be set later)
+    totalChapters: int = 0   # filled in after chapter extraction
+    sha256: str = ""         # full hex digest for dedup

--- a/backend/modules/textbook/routes.py
+++ b/backend/modules/textbook/routes.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File
 from db.utils import get_instructor_db
 from modules.auth.jwt_service import verify_access_token
@@ -79,8 +78,8 @@ async def upload_textbook(
         "filename": file.filename,
         "title": Path(file.filename).stem.replace("_", " ").replace("-", " "),
         "sha256": sha,
-        "totalChapters": 0,          # updated after chapter extraction
-        "pipelineStatus": "uploaded", # uploaded → chapters_extracted → quizzes_generated
+        "totalChapters": 0,           # updated after chapter extraction
+        "pipelineStatus": "uploaded",  # uploaded → chapters_extracted → quizzes_seeded
         "uploadedAt": datetime.now(timezone.utc).isoformat(),
     }
     await db["textbooks"].insert_one(doc)
@@ -120,21 +119,10 @@ async def get_textbook(
 async def seed_quiz_bank(
     textbook_id: str,
     request: Request,
-    db=Depends(get_instructor_db),
-):
-    """
-    Read all generated quiz JSON files from ``generated_quizzes/``
-    and insert them into the ``question_bank`` collection, tagged
-    with this *textbookId*.
-
-    These are the MASTER copies.  When an instructor creates a course,
-    the course-creation flow copies the relevant quizzes from
-    ``question_bank`` into the ``quizzes`` collection so instructors
-    can edit them freely.
-    """
+    db=Depends(get_instructor_db),):
+    
     _get_current_user(request)
 
-    # Verify textbook exists
     tb = await db["textbooks"].find_one({"textbookId": textbook_id})
     if not tb:
         raise HTTPException(404, "Textbook not found")
@@ -152,7 +140,7 @@ async def seed_quiz_bank(
     if not json_files:
         raise HTTPException(404, "No generated quiz JSON files found")
 
-    inserted = 0
+    sections = []
     skipped = 0
     errors = []
 
@@ -167,23 +155,29 @@ async def seed_quiz_bank(
             skipped += 1
             continue
 
-        # Re-tag with the real textbookId
-        quiz["textbookId"] = textbook_id
-        # Keep the model source info
-        quiz["sourceModel"] = fp.parent.name  # "opus" or "sonnet"
-        quiz["sourceFile"] = fp.name
-
-        # Use textbookId + quizId as the dedup key
-        existing = await db["question_bank"].find_one({
-            "textbookId": textbook_id,
-            "quizId": quiz.get("quizId"),
+        sections.append({
+            "section":     quiz.get("section"),
+            "quizId":      quiz.get("quizId"),
+            "sourceModel": fp.parent.name,
+            "sourceFile":  fp.name,
+            "questions":   quiz.get("questions", []),
         })
-        if existing:
-            skipped += 1
-            continue
 
-        await db["question_bank"].insert_one(quiz)
-        inserted += 1
+  
+    bank_doc = {
+        "textbookId":    textbook_id,
+        "title":         tb.get("title", ""),
+        "sectionCount":  len(sections),
+        "questionCount": sum(len(s["questions"]) for s in sections),
+        "sections":      sections,
+        "seededAt":      datetime.now(timezone.utc).isoformat(),
+    }
+
+    await db["question_bank"].replace_one(
+        {"textbookId": textbook_id},
+        bank_doc,
+        upsert=True,
+    )
 
     # Update textbook pipeline status
     await db["textbooks"].update_one(
@@ -192,8 +186,9 @@ async def seed_quiz_bank(
     )
 
     return {
-        "textbookId": textbook_id,
-        "inserted": inserted,
-        "skipped": skipped,
-        "errors": errors,
+        "textbookId":    textbook_id,
+        "sectionCount":  bank_doc["sectionCount"],
+        "questionCount": bank_doc["questionCount"],
+        "skipped":       skipped,
+        "errors":        errors,
     }

--- a/backend/modules/textbook/routes.py
+++ b/backend/modules/textbook/routes.py
@@ -1,0 +1,199 @@
+
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File
+from db.utils import get_instructor_db
+from modules.auth.jwt_service import verify_access_token
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+import shutil
+
+textbook_router = APIRouter(prefix="/textbook", tags=["Textbook"])
+
+UPLOAD_DIR = Path(__file__).resolve().parent.parent.parent.parent / "uploaded_textbooks"
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+QUIZ_OUTPUT_DIR = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "AI_core" / "quiz_pipeline" / "generated_quizzes"
+)
+
+
+def _get_current_user(request: Request) -> str:
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(401, "Not authenticated")
+    user_id = verify_access_token(token)
+    if not user_id:
+        raise HTTPException(401, "Invalid or expired token")
+    return user_id
+
+
+def _hash_bytes(data: bytes) -> str:
+    """Return the full SHA-256 hex digest of *data*."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_textbook_id(sha: str) -> str:
+    """Deterministic short ID derived from the SHA-256 digest."""
+    return f"TB_{sha[:12]}"
+
+
+# ── Upload ────────────────────────────────────────────────────────────────
+
+@textbook_router.post("/upload")
+async def upload_textbook(
+    request: Request,
+    file: UploadFile = File(...),
+    db=Depends(get_instructor_db),
+):
+    """
+    Upload a textbook PDF.
+
+    Returns the *textbookId*.  If the exact same PDF was uploaded before,
+    this returns the existing textbookId (idempotent).
+    """
+    _get_current_user(request)
+
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(400, "Only PDF files are accepted")
+
+    pdf_bytes = await file.read()
+    if len(pdf_bytes) == 0:
+        raise HTTPException(400, "Uploaded file is empty")
+
+    sha = _hash_bytes(pdf_bytes)
+    textbook_id = _make_textbook_id(sha)
+
+    # Check if this exact PDF already exists
+    existing = await db["textbooks"].find_one({"textbookId": textbook_id})
+    if existing:
+        existing["_id"] = str(existing["_id"])
+        return {"textbookId": textbook_id, "alreadyExisted": True, **existing}
+
+    # Save the PDF to disk
+    pdf_path = UPLOAD_DIR / f"{textbook_id}.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+
+    # Store metadata in MongoDB
+    doc = {
+        "textbookId": textbook_id,
+        "filename": file.filename,
+        "title": Path(file.filename).stem.replace("_", " ").replace("-", " "),
+        "sha256": sha,
+        "totalChapters": 0,          # updated after chapter extraction
+        "pipelineStatus": "uploaded", # uploaded → chapters_extracted → quizzes_generated
+        "uploadedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    await db["textbooks"].insert_one(doc)
+    doc["_id"] = str(doc["_id"])
+
+    return {"textbookId": textbook_id, "alreadyExisted": False, **doc}
+
+
+# ── List / Get ────────────────────────────────────────────────────────────
+
+@textbook_router.get("/list")
+async def list_textbooks(request: Request, db=Depends(get_instructor_db)):
+    _get_current_user(request)
+    docs = await db["textbooks"].find({}, {"sha256": 0}).to_list(None)
+    for d in docs:
+        d["_id"] = str(d["_id"])
+    return docs
+
+
+@textbook_router.get("/{textbook_id}")
+async def get_textbook(
+    textbook_id: str,
+    request: Request,
+    db=Depends(get_instructor_db),
+):
+    _get_current_user(request)
+    doc = await db["textbooks"].find_one({"textbookId": textbook_id})
+    if not doc:
+        raise HTTPException(404, "Textbook not found")
+    doc["_id"] = str(doc["_id"])
+    return doc
+
+
+# ── Seed question bank ───────────────────────────────────────────────────
+
+@textbook_router.post("/{textbook_id}/seed_quiz_bank")
+async def seed_quiz_bank(
+    textbook_id: str,
+    request: Request,
+    db=Depends(get_instructor_db),
+):
+    """
+    Read all generated quiz JSON files from ``generated_quizzes/``
+    and insert them into the ``question_bank`` collection, tagged
+    with this *textbookId*.
+
+    These are the MASTER copies.  When an instructor creates a course,
+    the course-creation flow copies the relevant quizzes from
+    ``question_bank`` into the ``quizzes`` collection so instructors
+    can edit them freely.
+    """
+    _get_current_user(request)
+
+    # Verify textbook exists
+    tb = await db["textbooks"].find_one({"textbookId": textbook_id})
+    if not tb:
+        raise HTTPException(404, "Textbook not found")
+
+    if not QUIZ_OUTPUT_DIR.exists():
+        raise HTTPException(
+            404,
+            f"Quiz output directory not found at {QUIZ_OUTPUT_DIR}. "
+            "Run the quiz pipeline first.",
+        )
+
+    import json
+
+    json_files = sorted(QUIZ_OUTPUT_DIR.rglob("*.json"))
+    if not json_files:
+        raise HTTPException(404, "No generated quiz JSON files found")
+
+    inserted = 0
+    skipped = 0
+    errors = []
+
+    for fp in json_files:
+        try:
+            quiz = json.loads(fp.read_text(encoding="utf-8"))
+        except Exception as e:
+            errors.append(f"{fp.name}: {e}")
+            continue
+
+        if quiz.get("_validation_errors"):
+            skipped += 1
+            continue
+
+        # Re-tag with the real textbookId
+        quiz["textbookId"] = textbook_id
+        # Keep the model source info
+        quiz["sourceModel"] = fp.parent.name  # "opus" or "sonnet"
+        quiz["sourceFile"] = fp.name
+
+        # Use textbookId + quizId as the dedup key
+        existing = await db["question_bank"].find_one({
+            "textbookId": textbook_id,
+            "quizId": quiz.get("quizId"),
+        })
+        if existing:
+            skipped += 1
+            continue
+
+        await db["question_bank"].insert_one(quiz)
+        inserted += 1
+
+    # Update textbook pipeline status
+    await db["textbooks"].update_one(
+        {"textbookId": textbook_id},
+        {"$set": {"pipelineStatus": "quizzes_seeded"}},
+    )
+
+    return {
+        "textbookId": textbook_id,
+        "inserted": inserted,
+        "skipped": skipped,
+        "errors": errors,
+    }


### PR DESCRIPTION
- Add seed_textbook.py CLI to hash PDF, store metadata, and seed question bank into MongoDB
- Add /textbook endpoints (upload, list, get, seed_quiz_bank)
- Update course creation to auto-copy question bank quizzes into course
- Closes #72

Description
Implements the textbook upload and question bank seeding pipeline that links textbooks to courses and their question banks via a deterministic textbookId.
What this does:

seed_textbook.py: CLI script that hashes the textbook PDF → generates a deterministic textbookId (TB_015b998d326c), stores metadata in the textbooks collection, and seeds all 13 chapter quizzes (260 questions) into a question_bank collection tagged with that textbookId.
backend/modules/textbook/: New FastAPI module with endpoints for uploading textbooks, listing them, and seeding the question bank via the API.
Updated course/routes.py: When a course is created with a textbookID, it auto-copies all matching quizzes from question_bank into the course's quizzes collection as editable drafts.

Already run against Atlas — 13 quiz documents successfully inserted into aiToolsDev.
Brendon: the course create modal will need to pass TB_015b998d326c as the textbookID instead of the raw PDF filename.
Related Issue
Closes #72
Unblocks #162, #163 (question bank management)
Type of Change

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Documentation update
 Refactor
 Test addition or correction

Checks

 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation.
 My changes generate no new warnings.
 I have added tests that prove my fix is effective or that my feature works.
 New and existing unit tests pass locally with my changes.
